### PR TITLE
Fixed an issue with csv conflict on qualifier character

### DIFF
--- a/DNN.Survey/Components/Controllers/SurveyBusinessController.cs
+++ b/DNN.Survey/Components/Controllers/SurveyBusinessController.cs
@@ -378,7 +378,7 @@ namespace DNN.Modules.Survey.Components.Controllers
                survey.Question,
                Localization.GetString(string.Format("QuestionType.{0}.Text", Enum.GetName(typeof(QuestionType), survey.OptionType), resourceFile)),
                survey.IsStatistical,
-               (survey.OptionType == QuestionType.Text ? survey.TextAnswer : survey.OptionName),
+               (survey.OptionType == QuestionType.Text ? EscapeTextQualifier(survey.TextAnswer, textQualifier) : survey.OptionName),
                survey.Votes,
                survey.IsCorrect,
                survey.UserID,
@@ -388,7 +388,20 @@ namespace DNN.Modules.Survey.Components.Controllers
          }
          return csvBuilder.ToString();
       }
-      private char GetSeparatorCharacter(Separator separator)
+
+        private string EscapeTextQualifier(string textAnswer, TextQualifier textQualifier)
+        {
+            var escapedAnswer = textAnswer;
+            string qualifier = GetTextQualifierCharacter(textQualifier).ToString();
+            if (textAnswer.Contains(qualifier))
+            {
+                escapedAnswer = textAnswer.Replace(qualifier, string.Format("{0}{0}", qualifier));
+            }
+
+            return escapedAnswer;
+        }
+
+        private char GetSeparatorCharacter(Separator separator)
       {
          char separatorCharacter;
          switch (separator)


### PR DESCRIPTION
When an answer included the string qualifier character, csv export was not properly escaping them. This PR fixed that.

<!-- 
Explain the benefit of this pull request
You can erase any parts of this template not applicable to your Pull Request. 
-->

### Description of PR...


## Changes made
- Item 1
- Item 2


## PR Template Checklist

- [ ] Fixes Bug
- [ ] Feature solution
- [ ] Other


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #