### PR TITLE
Hide buttons related to results when no results available

### DIFF
--- a/DNN.Survey/App_LocalResources/SurveyView.ascx.resx
+++ b/DNN.Survey/App_LocalResources/SurveyView.ascx.resx
@@ -144,6 +144,9 @@
   <data name="CorrectAnswers.Text" xml:space="preserve">
     <value>Correct answers</value>
   </data>
+  <data name="CountResults.Text" xml:space="preserve">
+    <value>The survey has been submitted {0} times.</value>
+  </data>
   <data name="DeleteResults.Action" xml:space="preserve">
     <value>Delete results</value>
   </data>

--- a/DNN.Survey/Components/Controllers/SurveyResultsController.cs
+++ b/DNN.Survey/Components/Controllers/SurveyResultsController.cs
@@ -82,6 +82,16 @@ namespace DNN.Modules.Survey.Components.Controllers
          }
          return surveyResult.ToList<SurveyResultInfo>();
       }
+
+      public int GetCount(int moduleID)
+      {
+         int count = 0;
+         using (IDataContext ctx = DataContext.Instance())
+         {
+            count = ctx.ExecuteScalar<int>(CommandType.StoredProcedure, "{databaseOwner}{objectQualifier}SurveyResults_Count", moduleID);
+         }
+         return count;
+      }
       #endregion
    }
 }

--- a/DNN.Survey/DNN.Survey.csproj
+++ b/DNN.Survey/DNN.Survey.csproj
@@ -240,6 +240,7 @@
     <Content Include="cake.config" />
     <None Include="packages.config" />
     <Content Include="Providers\DataProviders\SqlDataProvider\09.01.00.SqlDataProvider" />
+    <Content Include="Providers\DataProviders\SqlDataProvider\09.02.00.SqlDataProvider" />
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/DNN.Survey/Providers/DataProviders/SqlDataProvider/09.02.00.SqlDataProvider
+++ b/DNN.Survey/Providers/DataProviders/SqlDataProvider/09.02.00.SqlDataProvider
@@ -1,0 +1,32 @@
+/************************************************************/
+/*****                  SqlDataProvider                 *****/
+/*****                 Version: 09.02.00                *****/
+/*****                                                  *****/
+/*****  Note: To manually execute this script you must  *****/
+/*****        perform a search and replace operation    *****/
+/*****        for {databaseOwner} and {objectQualifier} *****/
+/*****                                                  *****/
+/************************************************************/
+
+IF EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}SurveyResults_Count') AND type = N'P')
+   DROP PROCEDURE {databaseOwner}{objectQualifier}SurveyResults_Count
+GO
+
+CREATE PROCEDURE {databaseOwner}{objectQualifier}SurveyResults_Count
+   @ModuleID int
+AS
+BEGIN
+   SELECT
+	   COUNT(*)
+   FROM
+      {databaseOwner}{objectQualifier}Surveys s
+      INNER JOIN {databaseOwner}{objectQualifier}SurveyOptions so ON so.SurveyID = s.SurveyID
+      INNER JOIN {databaseOwner}{objectQualifier}SurveyResults sr ON sr.SurveyOptionID = so.SurveyOptionID
+   WHERE
+      s.ModuleID = @ModuleID
+END
+GO
+
+/************************************************************/
+/*****              SqlDataProvider                     *****/
+/************************************************************/

--- a/DNN.Survey/Providers/DataProviders/SqlDataProvider/Uninstall.SqlDataProvider
+++ b/DNN.Survey/Providers/DataProviders/SqlDataProvider/Uninstall.SqlDataProvider
@@ -1,6 +1,6 @@
 ﻿/************************************************************/
 /*****             Uninstall.SqlDataProvider            *****/
-/*****                 Version: 09.00.00                *****/
+/*****                 Version: 09.02.00                *****/
 /*****                                                  *****/
 /*****  Note: To manually execute this script you must  *****/
 /*****        perform a search and replace operation    *****/
@@ -54,6 +54,10 @@ GO
 
 IF EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}SurveyResults_Get') AND type = N'P')
 DROP PROCEDURE {databaseOwner}{objectQualifier}SurveyResults_Get
+GO
+
+IF EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}SurveyResults_Count') AND type = N'P')
+   DROP PROCEDURE {databaseOwner}{objectQualifier}SurveyResults_Count
 GO
 
 IF EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{databaseOwner}{objectQualifier}vSurveys_CsvExport') AND type = N'V')

--- a/DNN.Survey/SurveyView.ascx
+++ b/DNN.Survey/SurveyView.ascx
@@ -52,4 +52,9 @@
             Visible="false" />
       </li>
    </ul>
+
+   <asp:Panel ID="CountResultsPanel" runat="server"
+      CssClass="dnnFormMessage dnnFormInfo">
+      <asp:Label ID="CountResultsLabel" runat="server" />
+   </asp:Panel>
 </div>

--- a/DNN.Survey/SurveyView.ascx.cs
+++ b/DNN.Survey/SurveyView.ascx.cs
@@ -55,6 +55,7 @@ namespace DNN.Modules.Survey
       private PortalSecurity _portalSecurity = null;
 
       private string _cookie;
+      private int? _countResults;
 
       protected ModulePermissionCollection ModulePermissionCollection
       {
@@ -198,6 +199,18 @@ namespace DNN.Modules.Survey
             return (authorizedUsersOnly);
          }
       }
+
+      protected int CountResults
+      {
+         get
+         {
+            if (!(_countResults.HasValue))
+            {
+               _countResults = SurveyResultsController.GetCount(ModuleId);
+            }
+            return _countResults.Value;
+         }
+      }
       #endregion
 
       #region Settings
@@ -338,7 +351,7 @@ namespace DNN.Modules.Survey
             // Add Question
             actions.Add(GetNextActionID(), Localization.GetString("AddQuestion.Action", LocalResourceFile), ModuleActionType.AddContent, string.Empty, string.Empty, EditUrl(), false, SecurityAccessLevel.Edit, true, false);
             actions.Add(GetNextActionID(), Localization.GetString("OrganizeQuestions.Action", LocalResourceFile), ModuleActionType.AddContent, string.Empty, IconController.IconURL("ViewStats"), EditUrl("Organize"), false, SecurityAccessLevel.Edit, true, false);
-            if (HasViewResultsPermission)
+            if (HasViewResultsPermission && (CountResults > 0))
             {
                // View Results
                actions.Add(GetNextActionID(), Localization.GetString("ViewResults.Action", LocalResourceFile), ModuleActionType.AddContent, string.Empty, IconController.IconURL("View"), EditUrl("SurveyResults"), false, SecurityAccessLevel.View, true, false);
@@ -422,9 +435,11 @@ namespace DNN.Modules.Survey
                }
             }
 
-            ViewResultsButton.Visible = HasViewResultsPermission;
-            ExportToCsvButton.Visible = HasEditPermission;
+            ViewResultsButton.Visible = (HasViewResultsPermission && (CountResults > 0));
+            ExportToCsvButton.Visible = (HasEditPermission && (CountResults > 0));
             ModuleHelpPanel.Visible = HasEditPermission;
+            CountResultsPanel.Visible = HasViewResultsPermission;
+            CountResultsLabel.Text = string.Format(Localization.GetString("CountResults", LocalResourceFile), CountResults);
             base.OnLoad(e);
          }
          catch (Exception ex)

--- a/DNN.Survey/SurveyView.ascx.designer.cs
+++ b/DNN.Survey/SurveyView.ascx.designer.cs
@@ -94,5 +94,23 @@ namespace DNN.Modules.Survey
       /// Zum Ändern Felddeklaration aus der Designerdatei in eine Code-Behind-Datei verschieben.
       /// </remarks>
       protected global::System.Web.UI.WebControls.LinkButton ExportToCsvButton;
+
+      /// <summary>
+      /// CountResultsPanel-Steuerelement.
+      /// </summary>
+      /// <remarks>
+      /// Automatisch generiertes Feld.
+      /// Zum Ändern Felddeklaration aus der Designerdatei in eine Code-Behind-Datei verschieben.
+      /// </remarks>
+      protected global::System.Web.UI.WebControls.Panel CountResultsPanel;
+
+      /// <summary>
+      /// CountResultsLabel-Steuerelement.
+      /// </summary>
+      /// <remarks>
+      /// Automatisch generiertes Feld.
+      /// Zum Ändern Felddeklaration aus der Designerdatei in eine Code-Behind-Datei verschieben.
+      /// </remarks>
+      protected global::System.Web.UI.WebControls.Label CountResultsLabel;
    }
 }


### PR DESCRIPTION
### Description of PR...
[View Results] and [Export survey results to CSV] buttons are hidden and the [View Results] option is removed from module action menu when no answers are submitted.

## Changes made
- Added StoredProcedure to count results
- Added message that displays the number of results to those who have View Results permission


## PR Template Checklist
- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other


## Please mark which issue is solved
Close #62
